### PR TITLE
adds file to run crawl command from docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,6 @@
 # soundcloudscraper
 # Runs test scrape.
-docker-compose up -d
-
-docker exec -it scrapy /bin/bash
-
-cd scrape_app
-
-python
-
-import scripts
-
-scripts.crawl('test')
+docker-compose up
 
 # View database through exposed port 5432 or:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,4 +19,5 @@ services:
       - database
     volumes:
       - ./scrapy-soundcloud/scrape_app:/scrape_app
-    tty: true
+    working_dir: /scrape_app
+    command: python run.py

--- a/scrapy-soundcloud/scrape_app/run.py
+++ b/scrapy-soundcloud/scrape_app/run.py
@@ -1,0 +1,6 @@
+import scripts
+from time import sleep
+
+sleep(10)
+
+scripts.crawl('test')


### PR DESCRIPTION
Okay so I've adjusted the docker-compose file so that it will perform the commands you've suggested after docker-compose up.

It does this by setting the working director, then running a python script which includes the import and run lines.

working_dir: /scrape_app == cd scrape_app
command: python run.py == import scripts, scripts.crawl('test')

I've had to put the sleep in because it gives the database time to boot and be in a state to accept connections. This is not a good way to do it, a better way would be to keep trying to connect until successful with a backoff timer, or get notified that the database is ready and then connect. For now, sleep will do.